### PR TITLE
fix: handle empty commits gracefully in auto-repair workflows

### DIFF
--- a/.github/workflows/auto-complete-repair.yml
+++ b/.github/workflows/auto-complete-repair.yml
@@ -35,17 +35,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if [ -n "$(git status --porcelain)" ]; then
-            BRANCH="auto-repair/$(date +%Y%m%d-%H%M%S)"
-            git checkout -b "$BRANCH"
-            git add .
-            git commit -m "fix: auto-repair formatting and lint issues"
-            git push origin "$BRANCH"
-            gh pr create \
-              --title "fix: auto-repair formatting and lint issues" \
-              --body "Automated code repair: formatting and lint fixes applied by CI pipeline." \
-              --base main \
-              --head "$BRANCH" || true
-          else
-            echo "No changes to commit"
-          fi
+          git add -A
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          BRANCH="auto-repair/$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git commit -m "fix: auto-repair formatting and lint issues"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "fix: auto-repair formatting and lint issues" \
+            --body "Automated code repair: formatting and lint fixes applied by CI pipeline." \
+            --base main \
+            --head "$BRANCH" || true

--- a/.github/workflows/zero-token-deploy.yml
+++ b/.github/workflows/zero-token-deploy.yml
@@ -169,7 +169,8 @@ jobs:
           git init
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
+          git add -A
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "Deploy to GitHub Pages"
           git push -f https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:gh-pages
           


### PR DESCRIPTION
## Summary
- Fix the "Auto-Complete Code Pipeline" workflow (`auto-complete-repair.yml`) which fails at the "Commit and push repairs" step with exit code 1 when there are no changes to commit
- Apply the same `git diff --staged --quiet` guard to the GitHub Pages deploy step in `zero-token-deploy.yml`
- All action versions audited — already at latest (`checkout@v6`, `setup-node@v6`, `setup-python@v6`, `upload-artifact@v7`)

## Changes
- **`auto-complete-repair.yml`**: Replaced `git status --porcelain` guard with `git add -A && git diff --staged --quiet` pattern that exits cleanly when there are no staged changes
- **`zero-token-deploy.yml`**: Added `git diff --staged --quiet` guard before the `git commit` in the gh-pages deploy step, replacing bare `git add .`

## Test plan
- [ ] Trigger "Auto-Complete Code Pipeline" manually via `workflow_dispatch` — should succeed with "No changes to commit" when there are no formatting/lint changes
- [ ] Trigger "Zero-Token Deploy" with `github-pages` target — should handle the case where page content hasn't changed
- [ ] Existing tests pass locally (9/9 passing; 2 blockchain suites are pre-existing failures due to missing `chai`/`hardhat` deps)

---
🤖 *Generated by Computer*

## Summary by Sourcery

Prevent CI auto-repair and GitHub Pages deploy workflows from failing when there are no changes to commit.

Bug Fixes:
- Guard the auto-complete repair workflow’s commit-and-push step so it exits successfully when no files have changed.
- Guard the GitHub Pages deployment commit step so it skips committing and pushing when there are no staged changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to prevent unnecessary commits and pull requests when no changes are staged.
  * Improved GitHub Pages deployment process to skip commit creation when deployed content is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->