### PR TITLE
fix: exclude workflow files from auto-repair git push

### DIFF
--- a/.github/workflows/auto-complete-repair.yml
+++ b/.github/workflows/auto-complete-repair.yml
@@ -35,7 +35,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git checkout -- .github/workflows/ 2>/dev/null || true
+          git add -A -- ':!.github/workflows/'
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           BRANCH="auto-repair/$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary

- The Auto-Complete Code Pipeline was failing because `git add -A` staged `.github/workflows/` files, and the GitHub Actions `GITHUB_TOKEN` cannot push workflow file changes (requires a PAT with `workflows` permission)
- Added `git checkout -- .github/workflows/` before staging to restore any modified workflow files
- Changed `git add -A` to `git add -A -- ':!.github/workflows/'` to explicitly exclude workflow files from being staged

## Test plan

- [ ] Verify the Auto-Complete Code Pipeline workflow runs successfully without the `remote rejected` error
- [ ] Confirm that non-workflow file changes (formatting, lint fixes) are still committed and pushed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update the auto-complete repair GitHub Actions workflow to reset any modified workflow files and exclude them from staged changes before committing.